### PR TITLE
Fixes large file unzipping

### DIFF
--- a/Unzipthis.cs
+++ b/Unzipthis.cs
@@ -44,7 +44,7 @@ namespace AzUnzipEverything
                         foreach(var zipArchiveEntry in zipArchive.Entries)
                         {
                             //Replace all NO digits, letters, or "-" by a "-" Azure storage is specific on valid characters
-                            var targetFileName = Regex.Replace(zipArchiveEntry.Name, @"[^a-zA-Z0-9\-]","-").ToLower();                            
+                            var targetFileName = Regex.Replace(zipArchiveEntry.Name, @"[^a-zA-Z0-9\-.]","-").ToLower();                            
                             var targetBlob = container.GetBlockBlobReference(targetFileName);
                             using(var sourceFileStream = zipArchiveEntry.Open())
                             {

--- a/Unzipthis.cs
+++ b/Unzipthis.cs
@@ -49,7 +49,7 @@ namespace AzUnzipEverything
 
                             using(var sourceFileStream = zipArchiveEntry.Open())
                             {
-                                log.LogInformation($"started extracting {zipArchiveEntry.Name} to {targetFileName}");
+                                log.LogInformation($"started extracting {zipArchiveEntry.Name} ({zipArchiveEntry.CompressedLength}) to {targetFileName} ({zipArchiveEntry.Length})");
                                 await targetBlob.UploadFromStreamAsync(sourceFileStream);
                                 log.LogInformation($"completed extracting {zipArchiveEntry.Name} to {targetFileName}");
                             }

--- a/Unzipthis.cs
+++ b/Unzipthis.cs
@@ -19,7 +19,7 @@ namespace AzUnzipEverything
             string name, 
             ILogger log)
         {
-            log.LogInformation($"C# Blob trigger function Processed blob Name:{name}");
+            log.LogInformation($"C# Blob trigger function Processed blob Name: {name}");
             
             // Exit if not a zip file
             if(name.Split('.').Last().ToLower() != "zip")
@@ -45,7 +45,8 @@ namespace AzUnzipEverything
                         {                            
                             //Replace all NO digits, letters, or "-" by a "-" Azure storage is specific on valid characters
                             var targetFileName = Regex.Replace(zipArchiveEntry.Name, @"[^a-zA-Z0-9\-.]","-").ToLower();                            
-                            var targetBlob = container.GetBlockBlobReference(targetFileName);
+                            var targetBlob = container.GetBlockBlobReference(targetFileName);                            
+
                             using(var sourceFileStream = zipArchiveEntry.Open())
                             {
                                 log.LogInformation($"started extracting {zipArchiveEntry.Name} to {targetFileName}");

--- a/deployment/deployAzure.json
+++ b/deployment/deployAzure.json
@@ -9,6 +9,13 @@
                 "description": "Name use as base-template to named the resources deployed in Azure."
             }
         },
+        "GitHubRepoUrl":{
+            "type": "string",
+            "defaultValue": "https://github.com/FBoucher/AzUnzipEverything.git",
+            "metadata": {
+                 "description": "Name of git hub repository to use when deploying (Default = https://github.com/FBoucher/AzUnzipEverything.git)."
+             } 
+        },
         "GitHubBranch": {
            "type": "string",
            "defaultValue": "master",
@@ -28,8 +35,7 @@
         "suffix": "[substring(toLower(uniqueString(resourceGroup().id, resourceGroup().location)),0,5)]",
         "funcAppName": "[toLower(concat(parameters('baseName'), variables('suffix')))]",
         "funcStorageName": "[tolower(concat(substring(parameters('baseName'), 0, min(length(parameters('baseName')),16)), 'stg', variables('suffix')))]",
-        "serverFarmName": "[concat(substring(parameters('baseName'), 0, min(length(parameters('baseName')),14)), '-srv-', variables('suffix'))]",
-        "repoURL": "https://github.com/FBoucher/AzUnzipEverything.git",
+        "serverFarmName": "[concat(substring(parameters('baseName'), 0, min(length(parameters('baseName')),14)), '-srv-', variables('suffix'))]",        
         "fileStorageName": "[tolower(concat(substring(parameters('MonitorStorageName'), 0, min(length(parameters('MonitorStorageName')),16)), 'stg', variables('suffix')))]"
     },
     "resources": [
@@ -95,7 +101,7 @@
                       "[resourceId('Microsoft.Web/sites/', variables('funcAppName'))]"
                     ],
                     "properties": {
-                        "RepoUrl": "[variables('repoURL')]",
+                        "RepoUrl": "[parameters('GitHubRepository')]",
                         "branch": "[parameters('GitHubBranch')]",
                         "publishRunbook": true,
                         "IsManualIntegration": true

--- a/deployment/deployAzure.json
+++ b/deployment/deployAzure.json
@@ -9,14 +9,14 @@
                 "description": "Name use as base-template to named the resources deployed in Azure."
             }
         },
-        "GitHubRepoUrl":{
+        "GitRepository":{
             "type": "string",
             "defaultValue": "https://github.com/FBoucher/AzUnzipEverything.git",
             "metadata": {
-                 "description": "Name of git hub repository to use when deploying (Default = https://github.com/FBoucher/AzUnzipEverything.git)."
+                 "description": "Name of git repository to use when deploying (Default = https://github.com/FBoucher/AzUnzipEverything.git)."
              } 
         },
-        "GitHubBranch": {
+        "GitBranch": {
            "type": "string",
            "defaultValue": "master",
            "metadata": {
@@ -101,8 +101,8 @@
                       "[resourceId('Microsoft.Web/sites/', variables('funcAppName'))]"
                     ],
                     "properties": {
-                        "RepoUrl": "[parameters('GitHubRepository')]",
-                        "branch": "[parameters('GitHubBranch')]",
+                        "RepoUrl": "[parameters('GitRepository')]",
+                        "branch": "[parameters('GitBranch')]",
                         "publishRunbook": true,
                         "IsManualIntegration": true
                     }

--- a/deployment/deployAzure.parameters.json
+++ b/deployment/deployAzure.parameters.json
@@ -5,8 +5,11 @@
         "baseName": {
             "value": "UnzipEverything"
         },
-        "GitHubBranch": {
+        "GitRepository": {
             "value": "master"
+        },
+        "GitBranch":{
+            "value":"https://github.com/FBoucher/AzUnzipEverything.git"
         },
         "MonitorStorageName": {
             "value": "dropzone"

--- a/deployment/deployAzure.parameters.json
+++ b/deployment/deployAzure.parameters.json
@@ -5,10 +5,10 @@
         "baseName": {
             "value": "UnzipEverything"
         },
-        "GitRepository": {
+        "GitBranch": {
             "value": "master"
         },
-        "GitBranch":{
+        "GitRepository":{
             "value":"https://github.com/FBoucher/AzUnzipEverything.git"
         },
         "MonitorStorageName": {

--- a/host.json
+++ b/host.json
@@ -1,3 +1,4 @@
 {
-    "version": "2.0"
+    "version": "2.0",
+    "functionTimeout": "00:10:00"
 }


### PR DESCRIPTION
Large zip files over 2GB run out of memory due to the use of a MemoryStream. This change directly uses the blob stream to move the file instead of first copying it to memory. See issue #24 

Because it isn't copying to memory first, I assume this will also speed up the unzip and may address #18 . 

This change also tries to preserve the extension in the zipped file name. The updated regex passes through '.' dots to the output file name. 

This change also adds additional logging to show what files are being extracted. 